### PR TITLE
Expose MavenVersion

### DIFF
--- a/mozilla_version/maven.py
+++ b/mozilla_version/maven.py
@@ -1,0 +1,56 @@
+"""Defines characteristics of a Maven version at Mozilla."""
+
+import attr
+import re
+
+from mozilla_version.version import BaseVersion
+
+
+@attr.s(frozen=True, cmp=False, hash=True)
+class MavenVersion(BaseVersion):
+    """Class that validates and handles Maven version numbers.
+
+    At Mozilla, Maven packages are used in projects like "GeckoView" or "Android-Components".
+    """
+
+    is_snapshot = attr.ib(type=bool, default=False)
+
+    _VALID_ENOUGH_VERSION_PATTERN = re.compile(r"""
+        ^(?P<major_number>\d+)
+        \.(?P<minor_number>\d+)
+        (\.(?P<patch_number>\d+))?
+        (?P<is_snapshot>-SNAPSHOT)?$""", re.VERBOSE)
+
+    @classmethod
+    def parse(cls, version_string):
+        """Construct an object representing a valid Maven version number."""
+        return super(MavenVersion, cls).parse(version_string, regex_groups=('is_snapshot', ))
+
+    def __str__(self):
+        """Implement string representation.
+
+        Computes a new string based on the given attributes.
+        """
+        string = super(MavenVersion, self).__str__()
+
+        if self.is_snapshot:
+            string = '{}-SNAPSHOT'.format(string)
+
+        return string
+
+    def _compare(self, other):
+        if isinstance(other, str):
+            other = MavenVersion.parse(other)
+        elif not isinstance(other, MavenVersion):
+            raise ValueError('Cannot compare "{}", type not supported!'.format(other))
+
+        difference = super(MavenVersion, self)._compare(other)
+        if difference != 0:
+            return difference
+
+        if not self.is_snapshot and other.is_snapshot:
+            return 1
+        elif self.is_snapshot and not other.is_snapshot:
+            return -1
+        else:
+            return 0

--- a/mozilla_version/parser.py
+++ b/mozilla_version/parser.py
@@ -13,3 +13,36 @@ def get_value_matched_by_regex(field_name, regex_matches, string):
         pass
 
     raise MissingFieldError(string, field_name)
+
+
+def does_regex_have_group(regex_matches, group_name):
+    """Return a boolean depending on whether a regex group is matched."""
+    try:
+        return regex_matches.group(group_name) is not None
+    except IndexError:
+        return False
+
+
+def positive_int(val):
+    """Parse `val` into a positive integer."""
+    if isinstance(val, float):
+        raise ValueError('"{}" must not be a float'.format(val))
+    val = int(val)
+    if val >= 0:
+        return val
+    raise ValueError('"{}" must be positive'.format(val))
+
+
+def positive_int_or_none(val):
+    """Parse `val` into either `None` or a positive integer."""
+    if val is None:
+        return val
+    return positive_int(val)
+
+
+def strictly_positive_int_or_none(val):
+    """Parse `val` into either `None` or a strictly positive integer."""
+    val = positive_int_or_none(val)
+    if val is None or val > 0:
+        return val
+    raise ValueError('"{}" must be strictly positive'.format(val))

--- a/mozilla_version/test/test_maven.py
+++ b/mozilla_version/test/test_maven.py
@@ -1,0 +1,87 @@
+import pytest
+
+from distutils.version import LooseVersion, StrictVersion
+
+from mozilla_version.errors import PatternNotMatchedError
+from mozilla_version.maven import MavenVersion
+
+@pytest.mark.parametrize('major_number, minor_number, patch_number, is_snapshot, expected_output_string', ((
+    32, 0, None, False, '32.0'
+), (
+    32, 0, 1, False, '32.0.1'
+), (
+    32, 0, None, True, '32.0-SNAPSHOT'
+), (
+    32, 0, 1, True, '32.0.1-SNAPSHOT'
+)))
+def test_maven_version_constructor_and_str(major_number, minor_number, patch_number, is_snapshot, expected_output_string):
+    assert str(MavenVersion(
+        major_number=major_number,
+        minor_number=minor_number,
+        patch_number=patch_number,
+        is_snapshot=is_snapshot,
+    )) == expected_output_string
+
+
+def test_maven_version_constructor_minimum_kwargs():
+    assert str(MavenVersion(32, 0)) == '32.0'
+    assert str(MavenVersion(32, 0, 1)) == '32.0.1'
+    assert str(MavenVersion(32, 1, 0)) == '32.1.0'
+    assert str(MavenVersion(32, 1, 0, False)) == '32.1.0'
+    assert str(MavenVersion(32, 1, 0, True)) == '32.1.0-SNAPSHOT'
+
+
+@pytest.mark.parametrize('version_string, ExpectedErrorType', (
+    ('32.0SNAPSHOT', PatternNotMatchedError),
+    ('32.1.0SNAPSHOT', PatternNotMatchedError),
+))
+def test_maven_version_raises_when_invalid_version_is_given(version_string, ExpectedErrorType):
+    with pytest.raises(ExpectedErrorType):
+        MavenVersion.parse(version_string)
+
+
+@pytest.mark.parametrize('previous, next', (
+    ('32.0-SNAPSHOT', '32.0'),
+    ('31.0', '32.0-SNAPSHOT'),
+    ('32.0', '32.0.1-SNAPSHOT'),
+    ('32.0.1-SNAPSHOT', '32.1.0'),
+    ('32.0.1-SNAPSHOT', '33.0'),
+))
+def test_maven_version_implements_lt_operator(previous, next):
+    assert MavenVersion.parse(previous) < MavenVersion.parse(next)
+
+
+@pytest.mark.parametrize('previous, next', (
+    ('32.0', '32.0-SNAPSHOT'),
+    ('32.0-SNAPSHOT', '31.0'),
+    ('32.0.1-SNAPSHOT', '32.0'),
+    ('32.1.0', '32.0.1-SNAPSHOT'),
+))
+def test_maven_version_implements_gt_operator(previous, next):
+    assert MavenVersion.parse(previous) > MavenVersion.parse(next)
+
+
+@pytest.mark.parametrize('wrong_type', (
+    32,
+    32.0,
+    ('32', '0', '1'),
+    ['32', '0', '1'],
+    LooseVersion('32.0'),
+    StrictVersion('32.0'),
+))
+def test_base_version_raises_eq_operator(wrong_type):
+    with pytest.raises(ValueError):
+        assert MavenVersion.parse('32.0') == wrong_type
+    # AttributeError is raised by LooseVersion and StrictVersion
+    with pytest.raises((ValueError, AttributeError)):
+        assert wrong_type == MavenVersion.parse('32.0')
+
+
+def test_maven_version_implements_eq_operator():
+    assert MavenVersion.parse('32.0-SNAPSHOT') == MavenVersion.parse('32.0-SNAPSHOT')
+    # raw strings are also converted
+    assert MavenVersion.parse('32.0-SNAPSHOT') == '32.0-SNAPSHOT'
+
+
+def test_maven_version_hashable():
+    hash(MavenVersion.parse('32.0.1'))

--- a/mozilla_version/test/test_version.py
+++ b/mozilla_version/test/test_version.py
@@ -1,6 +1,123 @@
 import pytest
 
-from mozilla_version.version import VersionType
+from distutils.version import LooseVersion, StrictVersion
+
+from mozilla_version.errors import PatternNotMatchedError
+from mozilla_version.version import BaseVersion, VersionType
+
+
+@pytest.mark.parametrize('major_number, minor_number, patch_number, expected_output_string', ((
+    32, 0, None, '32.0'
+), (
+    32, 0, 1, '32.0.1'
+)))
+def test_base_version_constructor_and_str(major_number, minor_number, patch_number, expected_output_string):
+    assert str(BaseVersion(
+        major_number=major_number,
+        minor_number=minor_number,
+        patch_number=patch_number,
+    )) == expected_output_string
+
+
+@pytest.mark.parametrize('major_number, minor_number, patch_number, ExpectedErrorType', ((
+    -1, 0, None, ValueError
+), (
+    32, -1, None, ValueError
+), (
+    32, 0, -1, ValueError
+), (
+    2.2, 0, 0, ValueError
+), (
+    'some string', 0, 0, ValueError
+)))
+def test_fail_base_version_constructor(major_number, minor_number, patch_number, ExpectedErrorType):
+    with pytest.raises(ExpectedErrorType):
+        BaseVersion(
+            major_number=major_number,
+            minor_number=minor_number,
+            patch_number=patch_number,
+        )
+
+
+def test_base_version_constructor_minimum_kwargs():
+    assert str(BaseVersion(32, 0)) == '32.0'
+    assert str(BaseVersion(32, 0, 1)) == '32.0.1'
+    assert str(BaseVersion(32, 1, 0)) == '32.1.0'
+
+
+@pytest.mark.parametrize('version_string, ExpectedErrorType', (
+    ('32', PatternNotMatchedError),
+    ('.1', PatternNotMatchedError),
+))
+def test_base_version_raises_when_invalid_version_is_given(version_string, ExpectedErrorType):
+    with pytest.raises(ExpectedErrorType):
+        BaseVersion.parse(version_string)
+
+
+@pytest.mark.parametrize('previous, next', (
+    ('32.0', '33.0'),
+    ('32.0', '32.1.0'),
+    ('32.0', '32.0.1'),
+
+    ('32.0.1', '33.0'),
+    ('32.0.1', '32.1.0'),
+    ('32.0.1', '32.0.2'),
+
+    ('32.1.0', '33.0'),
+    ('32.1.0', '32.2.0'),
+    ('32.1.0', '32.1.1'),
+
+    ('2.0', '10.0'),
+    ('10.2.0', '10.10.0'),
+    ('10.0.2', '10.0.10'),
+    ('10.10.1', '10.10.10'),
+))
+def test_base_version_implements_lt_operator(previous, next):
+    assert BaseVersion.parse(previous) < BaseVersion.parse(next)
+
+
+@pytest.mark.parametrize('equivalent_version_string', (
+    '32.0', '032.0', '32.00'
+))
+def test_base_version_implements_eq_operator(equivalent_version_string):
+    assert BaseVersion.parse('32.0') == BaseVersion.parse(equivalent_version_string)
+    # raw strings are also converted
+    assert BaseVersion.parse('32.0') == equivalent_version_string
+
+
+@pytest.mark.parametrize('wrong_type', (
+    32,
+    32.0,
+    ('32', '0', '1'),
+    ['32', '0', '1'],
+    LooseVersion('32.0'),
+    StrictVersion('32.0'),
+))
+def test_base_version_raises_eq_operator(wrong_type):
+    with pytest.raises(ValueError):
+        assert BaseVersion.parse('32.0') == wrong_type
+    # AttributeError is raised by LooseVersion and StrictVersion
+    with pytest.raises((ValueError, AttributeError)):
+        assert wrong_type == BaseVersion.parse('32.0')
+
+
+def test_base_version_implements_remaining_comparision_operators():
+    assert BaseVersion.parse('32.0') <= BaseVersion.parse('32.0')
+    assert BaseVersion.parse('32.0') <= BaseVersion.parse('33.0')
+
+    assert BaseVersion.parse('33.0') >= BaseVersion.parse('32.0')
+    assert BaseVersion.parse('33.0') >= BaseVersion.parse('33.0')
+
+    assert BaseVersion.parse('33.0') > BaseVersion.parse('32.0')
+    assert not BaseVersion.parse('33.0') > BaseVersion.parse('33.0')
+
+    assert not BaseVersion.parse('32.0') < BaseVersion.parse('32.0')
+
+    assert BaseVersion.parse('33.0') != BaseVersion.parse('32.0')
+
+
+def test_base_version_hashable():
+    hash(BaseVersion.parse('63.0'))
 
 
 @pytest.mark.parametrize('previous, next', (

--- a/mozilla_version/version.py
+++ b/mozilla_version/version.py
@@ -1,6 +1,120 @@
 """Defines common characteristics of a version at Mozilla."""
 
+import attr
+import re
+
 from enum import Enum
+
+from mozilla_version.errors import MissingFieldError, PatternNotMatchedError
+from mozilla_version.parser import (
+    get_value_matched_by_regex,
+    does_regex_have_group,
+    positive_int,
+    positive_int_or_none
+)
+
+
+@attr.s(frozen=True, cmp=False, hash=True)
+class BaseVersion(object):
+    """Class that validates and handles general version numbers."""
+
+    major_number = attr.ib(type=int, converter=positive_int)
+    minor_number = attr.ib(type=int, converter=positive_int)
+    patch_number = attr.ib(type=int, converter=positive_int_or_none, default=None)
+
+    _MANDATORY_NUMBERS = ('major_number', 'minor_number')
+    _OPTIONAL_NUMBERS = ('patch_number', )
+    _ALL_NUMBERS = _MANDATORY_NUMBERS + _OPTIONAL_NUMBERS
+
+    _VALID_ENOUGH_VERSION_PATTERN = re.compile(r"""
+        ^(?P<major_number>\d+)
+        \.(?P<minor_number>\d+)
+        (\.(?P<patch_number>\d+))?$""", re.VERBOSE)
+
+    @classmethod
+    def parse(cls, version_string, regex_groups=()):
+        """Construct an object representing a valid version number."""
+        regex_matches = cls._VALID_ENOUGH_VERSION_PATTERN.match(version_string)
+
+        if regex_matches is None:
+            raise PatternNotMatchedError(version_string, cls._VALID_ENOUGH_VERSION_PATTERN)
+
+        kwargs = {}
+
+        for field in cls._MANDATORY_NUMBERS:
+            kwargs[field] = get_value_matched_by_regex(field, regex_matches, version_string)
+        for field in cls._OPTIONAL_NUMBERS:
+            try:
+                kwargs[field] = get_value_matched_by_regex(field, regex_matches, version_string)
+            except MissingFieldError:
+                pass
+
+        for regex_group in regex_groups:
+            kwargs[regex_group] = does_regex_have_group(regex_matches, regex_group)
+
+        return cls(**kwargs)
+
+    def __str__(self):
+        """Implement string representation.
+
+        Computes a new string based on the given attributes.
+        """
+        semvers = [str(self.major_number), str(self.minor_number)]
+        if self.patch_number is not None:
+            semvers.append(str(self.patch_number))
+
+        return '.'.join(semvers)
+
+    def __eq__(self, other):
+        """Implement `==` operator."""
+        return self._compare(other) == 0
+
+    def __ne__(self, other):
+        """Implement `!=` operator."""
+        return self._compare(other) != 0
+
+    def __lt__(self, other):
+        """Implement `<` operator."""
+        return self._compare(other) < 0
+
+    def __le__(self, other):
+        """Implement `<=` operator."""
+        return self._compare(other) <= 0
+
+    def __gt__(self, other):
+        """Implement `>` operator."""
+        return self._compare(other) > 0
+
+    def __ge__(self, other):
+        """Implement `>=` operator."""
+        return self._compare(other) >= 0
+
+    def _compare(self, other):
+        """Compare this release with another.
+
+        Returns:
+            0 if equal
+            < 0 is this precedes the other
+            > 0 if the other precedes this
+
+        """
+        if isinstance(other, str):
+            other = BaseVersion.parse(other)
+        elif not isinstance(other, BaseVersion):
+            raise ValueError('Cannot compare "{}", type not supported!'.format(other))
+
+        for field in ('major_number', 'minor_number', 'patch_number'):
+            this_number = getattr(self, field)
+            this_number = 0 if this_number is None else this_number
+            other_number = getattr(other, field)
+            other_number = 0 if other_number is None else other_number
+
+            difference = this_number - other_number
+
+            if difference != 0:
+                return difference
+
+        return 0
 
 
 class VersionType(Enum):


### PR DESCRIPTION
maven-lambda needs a way to sort versions like "0.30.0-SNAPSHOT". I initially wanted to solve this in maven-lambda (with Loose/StrictVersion), but the architecture of mozilla-version made it easier. 