### PR TITLE
Run tests on Taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -5,23 +5,111 @@ version: 1
 policy:
   pullRequests: public
 tasks:
-  - schedulerId: taskcluster-github
-    created: {$fromNow: ''}
-    deadline: {$fromNow: '2 hours'}
-    expires: {$fromNow: '1 year'}
-    provisionerId: aws-provisioner-v1
-    workerType: github-worker
-    retries: 5
-    payload:
-      maxRunTime: 600
-      image: python:3.7-slim
-      command:
-        - /bin/bash
-        - --login
-        - -cx
-        - exit 0
-    metadata:
-      owner: JohanLorenzo@users.noreply.github.com
-      source: https://github.com/mozilla-releng/mozilla-version/pull/65
-      name: 'mozilla-version - noop'
-      description: 'noop task while https://github.com/mozilla-releng/mozilla-version/pull/64 lands'
+  $let:
+    expires_in: {$fromNow: '1 year'}
+    user: ${event.sender.login}
+
+    # We define the following variable at the very top, because they are used in the
+    # default definition
+    head_branch:
+      $if: 'tasks_for == "github-pull-request"'
+      then: ${event.pull_request.head.ref}
+      else:
+        $if: 'tasks_for == "github-push"'
+        then: ${event.ref}
+        else: ${event.release.target_commitish}
+
+    head_rev:
+      $if: 'tasks_for == "github-pull-request"'
+      then: ${event.pull_request.head.sha}
+      else:
+        $if: 'tasks_for == "github-push"'
+        then: ${event.after}
+        else: ${event.release.tag_name}
+
+    repository:
+      $if: 'tasks_for == "github-pull-request"'
+      then: ${event.pull_request.head.repo.html_url}
+      else: ${event.repository.html_url}
+
+    github_repository_full_name:
+      $if: 'tasks_for == "github-pull-request"'
+      then: ${event.pull_request.base.repo.full_name}
+      else: ${event.repository.full_name}
+
+  in:
+    $let:
+      short_head_branch:
+        $if: 'head_branch[:10] == "refs/tags/"'
+        then: {$eval: 'head_branch[10:]'}
+        else:
+          $if: 'head_branch[:11] == "refs/heads/"'
+          then: {$eval: 'head_branch[11:]'}
+          else: ${head_branch}
+
+      assume_scope_prefix: assume:repo:github.com/${github_repository_full_name}
+    in:
+      $let:
+        default_task_definition:
+          schedulerId: taskcluster-github
+          created: {$fromNow: ''}
+          deadline: {$fromNow: '2 hours'}
+          expires: ${expires_in}
+          provisionerId: aws-provisioner-v1
+          workerType: github-worker
+          retries: 5
+          payload:
+            maxRunTime: 600
+            command:
+              - /bin/bash
+              - --login
+              - -cx
+              - >-
+                git clone ${repository} /build
+                && cd /build
+                && git config advice.detachedHead false
+                && git checkout ${head_branch}
+                && pip install tox
+                && tox -e "$TOX_ENV"
+            env:
+              SKIP_NETWORK_TESTS: "0"
+          metadata:
+            owner: ${user}@users.noreply.github.com
+            source: ${repository}/raw/${head_rev}/.taskcluster.yml
+      in:
+        $flatten:
+          $map:
+            - short_name: 'py27'
+              image_tag: '2.7'
+            - short_name: 'py36'
+              image_tag: '3.6'
+            - short_name: 'py37'
+              image_tag: '3.7'
+          each(python_version):
+            $let:
+              python_task_definition:
+                payload:
+                  image: python:${python_version.image_tag}
+                  env:
+                    TOX_ENV: ${python_version.short_name}
+            in:
+              - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "edited", "synchronize"]'
+                then:
+                  $mergeDeep:
+                    - {$eval: 'default_task_definition'}
+                    - {$eval: 'python_task_definition'}
+                    - scopes:
+                        - ${assume_scope_prefix}:pull-request
+                      metadata:
+                        name: 'mozilla-version - ${python_version.short_name} (Pull Request #${event.pull_request.number})'
+                        description: 'Triggered by [#${event.pull_request.number}](${event.pull_request.html_url})'
+              - $if: 'tasks_for == "github-push" && head_branch[:10] != "refs/tags/"'
+                then:
+                  $mergeDeep:
+                    - {$eval: 'default_task_definition'}
+                    - {$eval: 'python_task_definition'}
+                    - scopes:
+                        - ${assume_scope_prefix}:branch:${short_head_branch}
+                      metadata:
+                        name: 'mozilla-version - ${python_version.short_name} (${head_rev})'
+                        description: 'Triggered by ${head_rev}'


### PR DESCRIPTION
Addresses some parts of https://github.com/mozilla-releng/mozilla-version/issues/53.

Depends on #65 

This port is not fully isofunctional compared to Travis-CI. I need to port coveralls too. If you're not using Travis, you need to provide a token https://coveralls-python.readthedocs.io/en/latest/usage/index.html. It seems we need a new type of workers to deal with this service. A TC secret can easily leak, since we must expose it to a PR. What do you think @rail ? 