### PR TITLE
Allow version to be within a bigger string

### DIFF
--- a/mozilla_version/balrog.py
+++ b/mozilla_version/balrog.py
@@ -87,7 +87,7 @@ class BalrogReleaseName(object):
 
     @classmethod
     def parse(cls, release_string):
-        """Construct an object representing a valid Firefox version number."""
+        """Construct an object representing a valid Balrog release name."""
         regex_matches = _VALID_ENOUGH_BALROG_RELEASE_PATTERN.match(release_string)
         if regex_matches is None:
             raise PatternNotMatchedError(release_string, (_VALID_ENOUGH_BALROG_RELEASE_PATTERN,))

--- a/mozilla_version/balrog.py
+++ b/mozilla_version/balrog.py
@@ -99,7 +99,7 @@ class BalrogReleaseName(object):
             raise PatternNotMatchedError(release_string, patterns=('unknown product',))
 
         version_string = get_value_matched_by_regex('version', regex_matches, release_string)
-        version = VersionClass.parse(version_string)
+        version = VersionClass.parse(version_string, is_within_bigger_string=False)
 
         return cls(product, version)
 

--- a/mozilla_version/gecko.py
+++ b/mozilla_version/gecko.py
@@ -219,7 +219,7 @@ class GeckoVersion(BaseVersion):
 
     @classmethod
     def parse(cls, version_string):
-        """Construct an object representing a valid Firefox version number."""
+        """Construct an object representing a valid Gecko version number."""
         return super(GeckoVersion, cls).parse(
             version_string, regex_groups=('is_nightly', 'is_aurora_or_devedition', 'is_esr')
         )

--- a/mozilla_version/gecko.py
+++ b/mozilla_version/gecko.py
@@ -47,7 +47,6 @@ Examples:
 """
 
 import attr
-import re
 
 from mozilla_version.errors import (
     PatternNotMatchedError, TooManyTypesError, NoVersionTypeError
@@ -111,8 +110,8 @@ class GeckoVersion(BaseVersion):
     # XXX This pattern doesn't catch all subtleties of a Firefox version (like 32.5 isn't valid).
     # This regex is intended to assign numbers. Then checks are done by attrs and
     # __attrs_post_init__()
-    _VALID_ENOUGH_VERSION_PATTERN = re.compile(r"""
-        ^(?P<major_number>\d+)
+    _VALID_ENOUGH_VERSION_PATTERN = r"""
+        (?P<major_number>\d+)
         \.(?P<minor_number>\d+)
         (\.(?P<patch_number>\d+))?
         (\.(?P<old_fourth_number>\d+))?
@@ -123,7 +122,7 @@ class GeckoVersion(BaseVersion):
             |b(?P<beta_number>\d+)
             |(?P<is_esr>esr)
         )?
-        -?(build(?P<build_number>\d+))?$""", re.VERBOSE)
+        -?(build(?P<build_number>\d+))?"""
 
     _OPTIONAL_NUMBERS = BaseVersion._OPTIONAL_NUMBERS + (
         'old_fourth_number', 'release_candidate_number', 'beta_number', 'build_number'
@@ -218,10 +217,12 @@ class GeckoVersion(BaseVersion):
             raise PatternNotMatchedError(self, patterns=error_messages)
 
     @classmethod
-    def parse(cls, version_string):
+    def parse(cls, version_string, is_within_bigger_string=False):
         """Construct an object representing a valid Gecko version number."""
         return super(GeckoVersion, cls).parse(
-            version_string, regex_groups=('is_nightly', 'is_aurora_or_devedition', 'is_esr')
+            version_string,
+            regex_groups=('is_nightly', 'is_aurora_or_devedition', 'is_esr'),
+            is_within_bigger_string=is_within_bigger_string,
         )
 
     @property
@@ -600,7 +601,7 @@ class GeckoSnapVersion(GeckoVersion):
     #   * no "build"
     #   * but mandatory dash and build number.
     # Example: 63.0b7-1
-    _VALID_ENOUGH_VERSION_PATTERN = re.compile(r"""
+    _VALID_ENOUGH_VERSION_PATTERN = r"""
         ^(?P<major_number>\d+)
         \.(?P<minor_number>\d+)
         (\.(?P<patch_number>\d+))?
@@ -609,7 +610,7 @@ class GeckoSnapVersion(GeckoVersion):
             |b(?P<beta_number>\d+)
             |(?P<is_esr>esr)
         )?
-        -(?P<build_number>\d+)$""", re.VERBOSE)
+        -(?P<build_number>\d+)$"""
 
     def __str__(self):
         """Implement string representation.

--- a/mozilla_version/maven.py
+++ b/mozilla_version/maven.py
@@ -1,7 +1,6 @@
 """Defines characteristics of a Maven version at Mozilla."""
 
 import attr
-import re
 
 from mozilla_version.version import BaseVersion
 
@@ -15,11 +14,11 @@ class MavenVersion(BaseVersion):
 
     is_snapshot = attr.ib(type=bool, default=False)
 
-    _VALID_ENOUGH_VERSION_PATTERN = re.compile(r"""
-        ^(?P<major_number>\d+)
+    _VALID_ENOUGH_VERSION_PATTERN = r"""
+        (?P<major_number>\d+)
         \.(?P<minor_number>\d+)
         (\.(?P<patch_number>\d+))?
-        (?P<is_snapshot>-SNAPSHOT)?$""", re.VERBOSE)
+        (?P<is_snapshot>-SNAPSHOT)?"""
 
     @classmethod
     def parse(cls, version_string):

--- a/mozilla_version/test/test_gecko.py
+++ b/mozilla_version/test/test_gecko.py
@@ -1,5 +1,4 @@
 import pytest
-import re
 
 from distutils.version import StrictVersion, LooseVersion
 
@@ -186,6 +185,38 @@ def test_gecko_version_raises_multiple_error_messages():
 def test_gecko_version_is_of_a_defined_type(version_string, expected_type):
     release = GeckoVersion.parse(version_string)
     assert getattr(release, 'is_{}'.format(expected_type))
+
+
+@pytest.mark.parametrize('string, expected', ((
+    '/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0a1.:lang.linux-i686.tar.bz',
+    '63.0a1',
+), (
+    '/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0a1.:lang.win32.installer.exe',
+    '63.0a1',
+), (
+    '/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0a1.:lang.linux-x86_64.tar.bz2',
+    '63.0a1',
+), (
+    '  /firefox/nightly/latest-mozilla-central/firefox-63.0a1.en-US.linux-x86_64.tar.bz2',
+    '63.0a1',
+), (
+    '/firefox/nightly/latest-mozilla-central/firefox-63.0a1.en-US.win32.installer.exe',
+    '63.0a1',
+), (
+    '/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0a1.:lang.win64.installer.exe',
+    '63.0a1',
+), (
+    '/firefox/nightly/latest-mozilla-central/firefox-63.0a1.en-US.win32.installer.exe',
+    '63.0a1',
+), (
+    'Firefox Setup 68.0.exe',
+    '68.0',
+), (
+    'https://archive.mozilla.org/pub/firefox/releases/69.0b8/win64/en-US/Firefox%20Setup%2069.0b8.msi',
+    '69.0b8',
+)))
+def test_gecko_version_parses_bigger_strings(string, expected):
+    assert str(GeckoVersion.parse(string, is_within_bigger_string=True)) == expected
 
 
 @pytest.mark.parametrize('previous, next', (
@@ -383,13 +414,11 @@ def test_gecko_version_bump_raises(version_string, field):
         version.bump(field)
 
 
-
-
-_SUPER_PERMISSIVE_PATTERN = re.compile(r"""
+_SUPER_PERMISSIVE_PATTERN = r"""
 (?P<major_number>\d+)\.(?P<minor_number>\d+)(\.(\d+))*
 (?P<is_nightly>a1)?(?P<is_aurora_or_devedition>a2)?(b(?P<beta_number>\d+))?
 (?P<is_esr>esr)?
-""", re.VERBOSE)
+"""
 
 
 @pytest.mark.parametrize('version_string', (
@@ -641,6 +670,17 @@ def test_fennec_version_bumps_raises(version_string, field):
     version = FennecVersion.parse(version_string)
     with pytest.raises(ValueError):
         version.bump(field)
+
+
+@pytest.mark.parametrize('string, expected', ((
+    '/mobile/nightly/latest-mozilla-esr68-android-api-16/fennec-68.1a1.:lang.android-arm.apk',
+    '68.1a1',
+), (
+    '/mobile/nightly/latest-mozilla-esr68-android-x86/fennec-68.1a1.:lang.android-i386.apk',
+    '68.1a1',
+)))
+def test_fennec_version_parses_bigger_strings(string, expected):
+    assert str(FennecVersion.parse(string, is_within_bigger_string=True)) == expected
 
 
 @pytest.mark.parametrize('version_string', (

--- a/mozilla_version/version.py
+++ b/mozilla_version/version.py
@@ -27,18 +27,23 @@ class BaseVersion(object):
     _OPTIONAL_NUMBERS = ('patch_number', )
     _ALL_NUMBERS = _MANDATORY_NUMBERS + _OPTIONAL_NUMBERS
 
-    _VALID_ENOUGH_VERSION_PATTERN = re.compile(r"""
-        ^(?P<major_number>\d+)
+    _VALID_ENOUGH_VERSION_PATTERN = r"""
+        (?P<major_number>\d+)
         \.(?P<minor_number>\d+)
-        (\.(?P<patch_number>\d+))?$""", re.VERBOSE)
+        (\.(?P<patch_number>\d+))?"""
 
     @classmethod
-    def parse(cls, version_string, regex_groups=()):
+    def parse(cls, version_string, regex_groups=(), is_within_bigger_string=False):
         """Construct an object representing a valid version number."""
-        regex_matches = cls._VALID_ENOUGH_VERSION_PATTERN.match(version_string)
+        if is_within_bigger_string:
+            pattern = cls._VALID_ENOUGH_VERSION_PATTERN
+            regex_matches = re.search(pattern, version_string, re.VERBOSE)
+        else:
+            pattern = '^{}$'.format(cls._VALID_ENOUGH_VERSION_PATTERN)
+            regex_matches = re.match(pattern, version_string, re.VERBOSE)
 
         if regex_matches is None:
-            raise PatternNotMatchedError(version_string, (cls._VALID_ENOUGH_VERSION_PATTERN,))
+            raise PatternNotMatchedError(version_string, (pattern,))
 
         kwargs = {}
 


### PR DESCRIPTION
Fixes #61 

This is how bouncerscript should look like https://github.com/mozilla-releng/mozilla-version/pull/66/files#diff-0a7ba49d8fa30825a6245b5e7565cedbR191. What do you think @MihaiTabara ?