### PR TITLE
Export all public version classes at package level

### DIFF
--- a/mozilla_version/__init__.py
+++ b/mozilla_version/__init__.py
@@ -1,1 +1,9 @@
 """Defines characteristics of Mozilla's version numbers."""
+
+from mozilla_version.gecko import (
+    DeveditionVersion,
+    FirefoxVersion,
+    ThunderbirdVersion,
+)
+from mozilla_version.maven import MavenVersion
+from mozilla_version.mobile import MobileVersion

--- a/mozilla_version/test/test_default_imports.py
+++ b/mozilla_version/test/test_default_imports.py
@@ -1,0 +1,14 @@
+import pytest
+
+import mozilla_version
+
+
+@pytest.mark.parametrize('version_type', [
+    'DeveditionVersion',
+    'FirefoxVersion',
+    'MavenVersion',
+    'MobileVersion',
+    'ThunderbirdVersion',
+])
+def test_(version_type):
+    getattr(mozilla_version, version_type)

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
 
 [flake8]
 max-line-length = 99
-exclude = .ropeproject,.tox,sandbox,docs,.eggs,*.egg,*.egg-info,setup.py,build/,mozilla_version/test/
+exclude = .ropeproject,.tox,sandbox,docs,.eggs,*.egg,*.egg-info,setup.py,build/,mozilla_version/__init__.py,mozilla_version/test/
 show-source = True
 
 [pytest]


### PR DESCRIPTION
By exporting all the public version classes that consumers are allowed to use globally in `__init__.py` it will make it much easier to use them given that you don't have to import specific modules:

```
from mozilla_version import MobileVersion
```

A real use-case example you can find at: https://github.com/mozilla/mozdownload/pull/632#discussion_r1171508495

@jcristau this is what we discussed on Matrix two days ago. I hope that it's clearer now.