### PR TITLE
Fix CI for untrusted pull requests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -15,7 +15,7 @@ tasks:
     # We define the following variable at the very top, because they are used in the
     # default definition
     head_branch:
-      $if: 'tasks_for == "github-pull-request"'
+      $if: 'tasks_for[:19] == "github-pull-request"'
       then: ${event.pull_request.head.ref}
       else:
         $if: 'tasks_for == "github-push"'
@@ -23,7 +23,7 @@ tasks:
         else: ${event.release.target_commitish}
 
     head_rev:
-      $if: 'tasks_for == "github-pull-request"'
+      $if: 'tasks_for[:19] == "github-pull-request"'
       then: ${event.pull_request.head.sha}
       else:
         $if: 'tasks_for == "github-push"'
@@ -31,12 +31,12 @@ tasks:
         else: ${event.release.tag_name}
 
     repository:
-      $if: 'tasks_for == "github-pull-request"'
+      $if: 'tasks_for[:19] == "github-pull-request"'
       then: ${event.pull_request.head.repo.html_url}
       else: ${event.repository.html_url}
 
     github_repository_full_name:
-      $if: 'tasks_for == "github-pull-request"'
+      $if: 'tasks_for[:19] == "github-pull-request"'
       then: ${event.pull_request.base.repo.full_name}
       else: ${event.repository.full_name}
 
@@ -106,13 +106,13 @@ tasks:
                   env:
                     TOX_ENV: ${python_version.short_name}
             in:
-              - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "edited", "synchronize"]'
+              - $if: 'tasks_for[:19] == "github-pull-request" && event["action"] in ["opened", "reopened", "edited", "synchronize"]'
                 then:
                   $mergeDeep:
                     - {$eval: 'default_task_definition'}
                     - {$eval: 'python_task_definition'}
                     - scopes:
-                        - ${assume_scope_prefix}:pull-request
+                          - ${assume_scope_prefix}:${tasks_for[7:]}
                       metadata:
                         name: 'mozilla-version - ${python_version.short_name} (Pull Request #${event.pull_request.number})'
                         description: 'Triggered by [#${event.pull_request.number}](${event.pull_request.html_url})'


### PR DESCRIPTION
053ad5378da608dbd0ee7327c686c861d7ac5d28 switched the policy to public_restricted, which means untrusted pull requests are now triggering tasks with `github-pull-request-untrusted`. In that context, the task rendering  tries to grab nonsensical values from the github event since it's checking for `tasks_for == "github-pull-request"` exactly. This commit relaxes the check to only check the beginning of `tasks_for` against `github-pull-request` which both trusted and untrusted PRs will match.

This also fixes a second oversight from the policy change, the task was assuming `:pull-request` all the time, even for untrusted ones which would fail since untrusted pull requests don't have that scope. In the pull request arm, assume the scope stripping `github-` from `tasks_for` which matches what taskcluster expects